### PR TITLE
Small corrections

### DIFF
--- a/src/SendEther.huff
+++ b/src/SendEther.huff
@@ -2,7 +2,7 @@
 /** 
  *  SEND_ETHER HUFF EXERCISE
  *  
- *  The task is to enable this contract, when called with function `distribute(address)` to
+ *  The task is to enable this contract, when called with function `sendEther(address)` to
  *  transfer the value sent with the call to the address in the argument.
  *
  *  NOTICE: The contract should revert when an unrecognized function is called

--- a/test/Keccak.t.sol
+++ b/test/Keccak.t.sol
@@ -4,9 +4,8 @@ pragma solidity ^0.8.13;
 import "forge-std/Test.sol";
 import {HuffConfig} from "foundry-huff/HuffConfig.sol";
 import {HuffDeployer} from "foundry-huff/HuffDeployer.sol";
-import {NonMatchingSelectorHelper} from "./test-utils/NonMatchingSelectorHelper.sol";
 
-contract KeccakTest is Test, NonMatchingSelectorHelper {
+contract KeccakTest is Test {
     address public keccak;
 
     function setUp() public {


### PR DESCRIPTION
Fixes a typo in `SendEther.huff` and removes an unused import from `Keccak.t.sol`.