### PR TITLE
Fixed test for "RevertString" challenge

### DIFF
--- a/test/RevertString.t.sol
+++ b/test/RevertString.t.sol
@@ -23,7 +23,7 @@ contract RevertStringTest is Test {
         require(!success, "call expected to fail");
         assertEq(
             keccak256(bytes("Only Huff")),
-            keccak256(abi.decode(revertData, (bytes))),
+            keccak256(revertData),
             "Expected the call to revert with custom error 'Only Huff' but it didn't "
         );
     }


### PR DESCRIPTION
removed the decode since the revert data isn't encoded